### PR TITLE
fix app start

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,4 +32,4 @@ app.get('/api/rates/:currency', async (req, res) => {
 expressUtils.hc(app);
 expressUtils.static(app);
 expressUtils.errorHandler(app);
-expressUtils.start(app, console, 8080, 'dev');
+expressUtils.start(app, 8080, 'dev');


### PR DESCRIPTION
This PR fixes app start.

Looking at docs: https://github.com/namshi/expressjs-utils#start 

```
expressUtils.start(app, 8080, 'dev');
```
accepts three parameters only